### PR TITLE
Fixed support for Razer Synapse 2.10+ on Windows 10 2004 and later.

### DIFF
--- a/ItzWarty.MiniSynapse.sln
+++ b/ItzWarty.MiniSynapse.sln
@@ -1,22 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30128.74
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ItzWarty.MiniSynapse", "ItzWarty.MiniSynapse\ItzWarty.MiniSynapse.csproj", "{69ACE22E-8599-4DD8-A53C-C0D320015F7A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Debug|x86.ActiveCfg = Debug|x86
+		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Debug|x86.Build.0 = Debug|x86
+		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Release|x86.ActiveCfg = Release|x86
+		{69ACE22E-8599-4DD8-A53C-C0D320015F7A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {117F73F5-1EA4-485C-B6F5-EDBD9C44D4CA}
 	EndGlobalSection
 EndGlobal

--- a/ItzWarty.MiniSynapse/App.config
+++ b/ItzWarty.MiniSynapse/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/ItzWarty.MiniSynapse/ItzWarty.MiniSynapse.csproj
+++ b/ItzWarty.MiniSynapse/ItzWarty.MiniSynapse.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ItzWarty.MiniSynapse</RootNamespace>
     <AssemblyName>ItzWarty.MiniSynapse</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +34,30 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RzCommon">

--- a/ItzWarty.MiniSynapse/Program.cs
+++ b/ItzWarty.MiniSynapse/Program.cs
@@ -1,38 +1,86 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Razer.Emily.Common;
 using Razer.Emily.UI;
 using Razer.Storage;
 
-namespace ItzWarty.MiniSynapse {
-   class Program {
-      [STAThread]
-      static void Main() {
-         var mainStorage = Singleton<MainStorage>.Instance;
-         mainStorage.Initialize(Storage_Project.Emily);
+namespace ItzWarty.MiniSynapse
+{
+    class Program
+    {
+        // ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
+        // NEEDED FOR SYNAPSE 2.x+
+        // ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
 
-         var isLoggedIn = mainStorage.TryLastLogin();
-         if (isLoggedIn != LoginStatus.Success) {
-            MessageBox.Show("Cannot configure your Razer devices - you need to login through Razer Synapse first.");
-         } else {
-            var deviceManager = new RzDeviceManager();
-            deviceManager.Enumerate();
+        const uint SPI_GETMOUSE = 0x0003;
+        const uint SPI_SETMOUSE = 0x0004;
 
-            var commonConfigLoader = Singleton<CommonConfigLoader>.Instance;
-            commonConfigLoader.StartConfig();
+        public enum SPIF
+        {
+            SPIF_NULL = 0x00,
+            SPIF_UPDATEINIFILE = 0x01,
+            SPIF_SENDCHANGE = 0x02,
+            SPIF_SENDWININICHANGE = 0x02
+        }
 
-            var devices = deviceManager.ActiveDevices.ToArray();
-            foreach (var device in devices) {
-               device.RefreshData();
-               commonConfigLoader.DeviceAdded(device.VID, device.PID);
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool SystemParametersInfo(uint uiAction, uint uiParam, IntPtr pvParam, SPIF fWinIni);
 
-               // The following code is unnecessary for the program's functioning: 
-               var pluginDevice = commonConfigLoader.FindDevice(device.PID);
-               Console.WriteLine("Configured device: " + pluginDevice.Name);
+        // ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
+        // NEEDED FOR SYNAPSE 2.x+
+        // ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
+
+        [STAThread]
+        private unsafe static void Main()
+        {
+            // Values
+            int[] MouseAccelParams = new int[3] { 0, 0, 0 };
+            GCHandle PArray = GCHandle.Alloc(MouseAccelParams, GCHandleType.Pinned);
+            IntPtr Pointer = PArray.AddrOfPinnedObject();
+
+            // Store the current Windows mouse pointer settings, such as speed and acceleration status
+            if (!SystemParametersInfo(SPI_GETMOUSE, 0, Pointer, 0))
+                MessageBox.Show("SPI_GETMOUSE failed!", "MiniSynapse - ERROR", MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+            // Log into Razer Synapse by using the last login data
+            MainStorage I1 = Singleton<MainStorage>.Instance;
+            I1.Initialize(Storage_Project.Emily);
+            if (I1.TryLastLogin() != LoginStatus.Success)
+            {
+                // Something went wrong and we were unable to login
+                MessageBox.Show("Cannot configure your Razer devices - you need to login through Razer Synapse first.");
+                PArray.Free();
+
+                return;
             }
 
-            MessageBox.Show("Razer Devices Loaded.\t\t","Mini Synapse", MessageBoxButtons.OK, MessageBoxIcon.Information);
-         }
-      }
-   }
+            // Enumerate all the installed Razer Synapse 2.x devices
+            RzDeviceManager RazerDM = new RzDeviceManager();
+            RazerDM.Enumerate();
+
+            // Initialize the settings loader
+            CommonConfigLoader I2 = Singleton<CommonConfigLoader>.Instance;
+            I2.StartConfig();
+
+            // Apply the Razer Synapse settings to the device
+            foreach (RzDevice RazerDevice in RazerDM.ActiveDevices.ToArray())
+            {
+                RazerDevice.RefreshData();
+                I2.DeviceAdded(RazerDevice.VID, RazerDevice.PID);
+                Console.WriteLine("Configured device: " + I2.FindDevice(RazerDevice.PID).Name);
+            }
+
+            // Restore the mouse settings back, since Synapse 2.10+ seem to reset them
+            if (!SystemParametersInfo(SPI_SETMOUSE, 0, Pointer, SPIF.SPIF_SENDCHANGE))
+                MessageBox.Show("SPI_SETMOUSE failed!", "MiniSynapse - ERROR", MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+            // Free the GCHandle since we don't need it anymore
+            PArray.Free();
+
+            return;
+        }
+    }
 }

--- a/ItzWarty.MiniSynapse/Properties/AssemblyInfo.cs
+++ b/ItzWarty.MiniSynapse/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ItzWarty.MiniSynapse")]
-[assembly: AssemblyCopyright("Copyright © ItzWarty 2015")]
+[assembly: AssemblyCopyright("Copyright © ItzWarty 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]


### PR DESCRIPTION
Used binaries:
- **RzCommon** _2.1.0.29282_
- **RzStorage** _2.1.0.29282_
- **RzSynapse** _2.21.24.34_
- **RzUiSdk** _2.21.24.34_

A precompiled binary is available in my fork.